### PR TITLE
Do not expose private methods

### DIFF
--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -26,6 +26,12 @@ class Module3(object):
     def cd(self):
         pass
 
+    def _ef(self):
+        pass
+
+    def __gh(self):
+        pass
+
 
 class RouterTest(unittest.TestCase):
     def setUp(self):

--- a/ubersmith_remote_module_server/router.py
+++ b/ubersmith_remote_module_server/router.py
@@ -33,4 +33,4 @@ class Router(object):
 
     def list_implemented_methods(self, module_name):
         module = self.modules[module_name]
-        return [method for method in dir(module) if callable(getattr(module, method)) and not method.startswith('__')]
+        return [method for method in dir(module) if callable(getattr(module, method)) and not method.startswith('_')]


### PR DESCRIPTION
Methods that starts with an underscore should not be exposed to the API.
