### PR TITLE
Configure Flask to make sure exceptions are propagated

### DIFF
--- a/ubersmith_remote_module_server/server.py
+++ b/ubersmith_remote_module_server/server.py
@@ -20,6 +20,7 @@ class Server(object):
     def __init__(self, modules):
         self.router = router.Router()
         self.app = Flask(__name__)
+        self.app.config['PROPAGATE_EXCEPTIONS']
         self.api = api.Api(modules, self.app, self.router)
 
     def run(self, *args, **kwargs):


### PR DESCRIPTION
explicitly enable or disable the propagation of exceptions.
If not set or explicitly set to None this is implicitly true
if either TESTING or DEBUG is true.
