### PR TITLE
Allow calls to legacy ubersmith with UbersmithCore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 flask==0.10.1
+python-ubersmithclient>=2.0.6
+six

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 nose>=1.2.1
 mock>=1.0.1
 pyhamcrest>=1.6
+flexmock>=0.10.2

--- a/tests/Integration/__init__.py
+++ b/tests/Integration/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2016 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class ContextMatcher(object):
+    def __init__(self, callback_url, module_id, device_id=None, service_id=None):
+        self.callback_url = callback_url
+        self.module_id = module_id
+        self.device_id = device_id
+        self.service_id = service_id
+
+    def __eq__(self, other):
+        return self.callback_url == other.callback_url and \
+               self.module_id == other.module_id and \
+               ((self.device_id and self.device_id == other.device_id) or
+                (self.service_id and self.service_id == other.service_id))

--- a/tests/Integration/test_router_ubersmith_core.py
+++ b/tests/Integration/test_router_ubersmith_core.py
@@ -1,0 +1,88 @@
+# Copyright 2016 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from flexmock import flexmock, flexmock_teardown
+
+from . import ContextMatcher
+from ubersmith_remote_module_server import ubersmith_core
+from ubersmith_remote_module_server.objects import RequestContext
+from ubersmith_remote_module_server.router import Router
+from ubersmith_remote_module_server.ubersmith_core import UbersmithCore
+
+
+class FakeModule(object):
+    def call_uber_core(self):
+        UbersmithCore.test()
+
+
+class RouterUbersmithCoreTest(unittest.TestCase):
+    def test_a_module_can_call_ubersmith_core_without_context(self):
+        fake_module = FakeModule()
+        remote_executor_mock = flexmock()
+
+        flexmock(ubersmith_core).should_receive('RemoteExecutor').\
+            with_args(context=RequestContext).and_return(remote_executor_mock)
+
+        remote_executor_mock.should_receive('invoke_global').with_args('test', args={}).once()
+
+        self.basic_router = Router(env_as_kwarg=False)
+        self.basic_router.invoke_method(module=fake_module, method='call_uber_core')
+
+    def test_module_context_is_injected_when_service_module(self):
+        fake_module = FakeModule()
+        remote_executor_mock = flexmock()
+
+        example_callback = {'params': {'module_id': '44', 'service_id': '1260'},
+                            'url': 'http://user:pass@ubersmith.example/'
+                                   'api/2.0/?method=service.module_call'}
+
+        flexmock(ubersmith_core).should_receive('RemoteExecutor'). \
+            with_args(context=ContextMatcher(callback_url=example_callback['url'],
+                                             module_id='44',
+                                             service_id='1260'))\
+            .and_return(remote_executor_mock)
+
+        remote_executor_mock.should_receive('invoke_global')
+
+        self.basic_router = Router(env_as_kwarg=False)
+        self.basic_router.invoke_method(module=fake_module,
+                                        method='call_uber_core',
+                                        callback=example_callback)
+
+    def test_module_context_is_injected_when_device_module(self):
+        fake_module = FakeModule()
+
+        example_callback = {'params': {'module_id': '173', 'device_id': '200025'},
+                            'url': 'http://user:pass@ubersmith.example/'
+                                   'api/2.0/?method=device.module_call'}
+
+        remote_executor_mock = flexmock()
+        flexmock(ubersmith_core).should_receive('RemoteExecutor'). \
+            with_args(context=ContextMatcher(callback_url=example_callback['url'],
+                                             module_id='173',
+                                             device_id='200025'))\
+            .and_return(remote_executor_mock)
+
+        remote_executor_mock.should_receive('invoke_global')
+
+        self.basic_router = Router(env_as_kwarg=False)
+        self.basic_router.invoke_method(module=fake_module,
+                                        method='call_uber_core',
+                                        callback=example_callback)
+
+    def tearDown(self):
+        flexmock_teardown()
+        super(RouterUbersmithCoreTest, self).tearDown()

--- a/tests/test_remote_executor.py
+++ b/tests/test_remote_executor.py
@@ -1,0 +1,78 @@
+# Copyright 2016 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from flexmock import flexmock, flexmock_teardown
+
+from ubersmith_remote_module_server import _remote_executor
+from ubersmith_remote_module_server._remote_executor import RemoteExecutor
+from ubersmith_remote_module_server.objects import RequestContext
+from . import mock_ubersmith_client, mock_ubersmith_api
+
+
+class RemoteExecutorTest(unittest.TestCase):
+    def test_invoke_global_from_device_module(self):
+        ubersmith_client = mock_ubersmith_client()
+        ubersmith_api = mock_ubersmith_api()
+
+        flexmock(_remote_executor).should_receive('ubersmith_client').and_return(ubersmith_client)
+
+        ubersmith_client.api.should_receive('init')\
+            .with_args(url='http://ubersmith.example/url',
+                       password='pass',
+                       user='user')\
+            .and_return(ubersmith_api)
+
+        ubersmith_api.device.should_receive('module_call').\
+            with_args(device_id=20025,
+                      function='_web_hook_invoke_global',
+                      module_id=173,
+                      module_params=['logevent', [dict(action='hello from python')]])
+
+        remote_executor = RemoteExecutor(
+            context=RequestContext(callback_url='http://user:pass@ubersmith.example/url',
+                                   module_id=173, device_id=20025))
+        remote_executor.invoke_global('logevent', dict(action='hello from python'))
+
+    def test_invoke_global_from_service_module(self):
+        ubersmith_client = mock_ubersmith_client()
+        ubersmith_api = mock_ubersmith_api()
+
+        flexmock(_remote_executor).should_receive('ubersmith_client').and_return(ubersmith_client)
+
+        ubersmith_client.api.should_receive('init')\
+            .with_args(url='http://ubersmith.example/url',
+                       password='pass',
+                       user='user')\
+            .and_return(ubersmith_api)
+
+        ubersmith_api.client.should_receive('service_module_call').\
+            with_args(service_id=1260,
+                      function='_web_hook_invoke_global',
+                      module_id=44,
+                      module_params=['logevent', [dict(action='hello from python')]])
+
+        remote_executor = RemoteExecutor(
+            context=RequestContext(callback_url='http://user:pass@ubersmith.example/'
+                                                'url?method=method',
+                                   module_id=44,
+                                   service_id=1260))
+        remote_executor.invoke_global('logevent', dict(action='hello from python'))
+
+    def tearDown(self):
+        flexmock_teardown()
+        super(RemoteExecutorTest, self).tearDown()
+
+

--- a/tests/test_ubersmith_core.py
+++ b/tests/test_ubersmith_core.py
@@ -1,0 +1,49 @@
+# Copyright 2016 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from flexmock import flexmock, flexmock_teardown
+
+from ubersmith_remote_module_server import ubersmith_core
+from ubersmith_remote_module_server.exceptions import NamedArgumentsOnly
+from ubersmith_remote_module_server.ubersmith_core import NoRequestContext, UbersmithCore, \
+    ConfiguredRequestContext
+
+
+class UbersmithCoreTest(unittest.TestCase):
+    def test_raises_when_out_of_context(self):
+        remote_executor_mock = flexmock()
+        flexmock(ubersmith_core).should_receive('RemoteExecutor').and_return(remote_executor_mock)
+        with self.assertRaises(NoRequestContext):
+            UbersmithCore.test()
+
+    def test_raises_when_args(self):
+        remote_executor_mock = flexmock()
+        flexmock(ubersmith_core).should_receive('RemoteExecutor').and_return(remote_executor_mock)
+        with self.assertRaises(NamedArgumentsOnly):
+            UbersmithCore.test('hello')
+
+    def test_calls_executor_with_context_when_called(self):
+        remote_executor_mock = flexmock()
+        flexmock(ubersmith_core).should_receive('RemoteExecutor').\
+            with_args(context='context').and_return(remote_executor_mock).once()
+        remote_executor_mock.should_receive('invoke_global').with_args('test', args={}).once()
+
+        with ConfiguredRequestContext(context='context'):
+            UbersmithCore.test()
+
+    def tearDown(self):
+        flexmock_teardown()
+        super(UbersmithCoreTest, self).tearDown()

--- a/ubersmith_remote_module_server/_remote_executor.py
+++ b/ubersmith_remote_module_server/_remote_executor.py
@@ -1,0 +1,38 @@
+# Copyright 2016 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ubersmith_client
+from six.moves.urllib.parse import urlparse
+
+
+class RemoteExecutor(object):
+    def __init__(self, context):
+        self.context = context
+
+    def invoke_global(self, func_name, args):
+        url = urlparse(self.context.callback_url)
+        ubersmith_url = "{0}://{1}{2}".format(url.scheme, url.hostname, url.path)
+        ubersmith_api = ubersmith_client.api.init(url=ubersmith_url,
+                                                  user=url.username,
+                                                  password=url.password)
+        if self.context.device_id:
+            ubersmith_api.device.module_call(device_id=self.context.device_id,
+                                             module_id=self.context.module_id,
+                                             function='_web_hook_invoke_global',
+                                             module_params=[func_name, [args]])
+        else:
+            ubersmith_api.client.service_module_call(service_id=self.context.service_id,
+                                                     module_id=self.context.module_id,
+                                                     function='_web_hook_invoke_global',
+                                                     module_params=[func_name, [args]])

--- a/ubersmith_remote_module_server/exceptions.py
+++ b/ubersmith_remote_module_server/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Internap.
+# Copyright 2016 Internap.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,17 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from flexmock import flexmock
+
+class NoRequestContext(Exception):
+    def __init__(self, msg="UbersmithCore was called without a context, "
+                           "you can't save this object"):
+        super(NoRequestContext, self).__init__(msg)
 
 
-def mock_ubersmith_client():
-    ubersmith_client = flexmock()
-    ubersmith_client.api = flexmock()
-    return ubersmith_client
-
-
-def mock_ubersmith_api():
-    ubersmith_api = flexmock()
-    ubersmith_api.device = flexmock()
-    ubersmith_api.client = flexmock()
-    return ubersmith_api
+class NamedArgumentsOnly(Exception):
+    def __init__(self, msg="UbersmithCore was called with non-named arguments, "
+                           "you MUST use named arguments (kwargs)"):
+        super(NamedArgumentsOnly, self).__init__(msg)

--- a/ubersmith_remote_module_server/objects.py
+++ b/ubersmith_remote_module_server/objects.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Internap.
+# Copyright 2016 Internap.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,17 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from flexmock import flexmock
 
-
-def mock_ubersmith_client():
-    ubersmith_client = flexmock()
-    ubersmith_client.api = flexmock()
-    return ubersmith_client
-
-
-def mock_ubersmith_api():
-    ubersmith_api = flexmock()
-    ubersmith_api.device = flexmock()
-    ubersmith_api.client = flexmock()
-    return ubersmith_api
+class RequestContext(object):
+    def __init__(self, callback_url='', module_id='', device_id=None, service_id=None):
+        self.callback_url = callback_url
+        self.module_id = module_id
+        self.device_id = device_id
+        self.service_id = service_id

--- a/ubersmith_remote_module_server/ubersmith_core.py
+++ b/ubersmith_remote_module_server/ubersmith_core.py
@@ -1,0 +1,53 @@
+# Copyright 2016 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from six import with_metaclass
+
+from ubersmith_remote_module_server._remote_executor import RemoteExecutor
+from ubersmith_remote_module_server.exceptions import NoRequestContext, NamedArgumentsOnly
+
+_configuration = None
+
+
+class ConfiguredRequestContext(object):
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs or {}
+
+    def __enter__(self):
+        global _configuration
+        _configuration = self.kwargs
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        global _configuration
+        _configuration = None
+
+
+class UbersmithCoreMeta(type):
+    def _invoke_method(cls, name, *args, **kwargs):
+        global _configuration
+        if args:
+            raise NamedArgumentsOnly()
+        if _configuration is None:
+            raise NoRequestContext()
+        executor = RemoteExecutor(**_configuration)
+        executor.invoke_global(name, args=kwargs)
+
+    def __getattr__(cls, func_name):
+        def invoke_without_name(*args, **kwargs):
+            return cls._invoke_method(func_name, *args, **kwargs)
+        return invoke_without_name
+
+
+class UbersmithCore(with_metaclass(UbersmithCoreMeta, object)):
+    __doc__ = """ This class is configured to wire the calls to ubersmith"""


### PR DESCRIPTION
This new class will allow to relay php function call from python. The
parameters will be autowired on call and it will allow you to call
ubersmith's internal php function.